### PR TITLE
Fix String#slice! raise TypeError.

### DIFF
--- a/mrblib/string_pcre.rb
+++ b/mrblib/string_pcre.rb
@@ -337,6 +337,6 @@ class String
   end
 
   def splice(start , count, val)
-    self.replace(self[0...start] + val + self[(start + count)..-1])
+    self.replace(self[0...start] + val + self[(start + count)..-1].to_s)
   end
 end


### PR DESCRIPTION
String#slice! raise TypeError:

```
% mruby -e '"0123456789".slice!(0, 11)'    
trace:
    [3] /home/tommy/work/mruby-iij/build/mrbgems/mruby-regexp-pcre/mrblib/string_pcre.rb:340:in String.splice
    [2] /home/tommy/work/mruby-iij/build/mrbgems/mruby-regexp-pcre/mrblib/string_pcre.rb:289:in String.[]=
    [1] /home/tommy/work/mruby-iij/build/mrbgems/mruby-regexp-pcre/mrblib/string_pcre.rb:186:in String.slice!
    [0] -e:1
/home/tommy/work/mruby-iij/build/mrbgems/mruby-regexp-pcre/mrblib/string_pcre.rb:340: expected String (TypeError)
```
