### PR TITLE
mrbgem.rake: Make mruby-regexp-pcre buildable on mingw and Visual C++

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -26,6 +26,7 @@ MRuby::Gem::Specification.new('mruby-regexp-pcre') do |spec|
   pcre_src = "#{spec.dir}/#{pcre_dirname}"
   spec.cc.include_paths << "#{pcre_src}"
   spec.cc.flags << '-DHAVE_CONFIG_H'
+  spec.cc.flags << '-DPCRE_STATIC' if /mingw|mswin/ =~ RUBY_PLATFORM
 
   spec.objs += %W(
     #{pcre_src}/pcre_byte_order.c
@@ -49,7 +50,7 @@ MRuby::Gem::Specification.new('mruby-regexp-pcre') do |spec|
     #{pcre_src}/pcre_version.c
     #{pcre_src}/pcre_xclass.c
     #{pcre_src}/pcre_chartables.c
-  ).map { |f| f.relative_path_from(dir).pathmap("#{build_dir}/%X.o") }
+  ).map { |f| f.relative_path_from(dir).pathmap("#{build_dir}/%X#{spec.exts.object}" ) }
 
   desc "generate configuration files for mruby-regexp-pcre"
   task :regexp_pcre_config do


### PR DESCRIPTION
This PR fixes the following link error on mingw, and uses appropriate object file extension for Visual C++. 

```
LD    build/host/bin/mirb.exe
c:/dev/mruby/build/host/lib/libmruby.a(mruby_regexp_pcre.o): In function `mrb_regexp_free':
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:32: undefined reference to `_imp__pcre_free'
c:/dev/mruby/build/host/lib/libmruby.a(mruby_regexp_pcre.o): In function `regexp_pcre_initialize':
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:116: undefined reference to `_imp__pcre_compile'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:123: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:125: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:126: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/host/lib/libmruby.a(mruby_regexp_pcre.o): In function `regexp_pcre_match':
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:160: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:170: undefined reference to `_imp__pcre_exec'
collect2.exe: error: ld returned 1 exit status
c:/dev/mruby/build/host/lib/libmruby.a(mruby_regexp_pcre.o): In function `mrb_regexp_free':
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:32: undefined reference to `_imp__pcre_free'
c:/dev/mruby/build/host/lib/libmruby.a(mruby_regexp_pcre.o): In function `regexp_pcre_initialize':
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:116: undefined reference to `_imp__pcre_compile'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:123: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:125: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:126: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/host/lib/libmruby.a(mruby_regexp_pcre.o): In function `regexp_pcre_match':
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:160: undefined reference to `_imp__pcre_fullinfo'
c:/dev/mruby/build/mrbgems/mruby-regexp-pcre/src/mruby_regexp_pcre.c:170: undefined reference to `_imp__pcre_exec'
collect2.exe: error: ld returned 1 exit status
rake aborted!
Command failed with status (1): [gcc --coverage -L"C:/Windows/system" -o "c...]
c:/dev/mruby/tasks/mruby_build_commands.rake:31:in `_run'
c:/dev/mruby/tasks/mruby_build_commands.rake:36:in `rescue in _run'
c:/dev/mruby/tasks/mruby_build_commands.rake:32:in `_run'
c:/dev/mruby/tasks/mruby_build_commands.rake:180:in `run'
c:/dev/mruby/Rakefile:67:in `block (4 levels) in <top (required)>'
Tasks: TOP => default => all => c:/dev/mruby/bin/mirb.exe => c:/dev/mruby/build/host/bin/mirb.exe
(See full trace by running task with --trace)
```
