### PR TITLE
Fetch named captures with the array subscript operator

### DIFF
--- a/mrblib/regexp_pcre.rb
+++ b/mrblib/regexp_pcre.rb
@@ -151,20 +151,32 @@ class MatchData
   attr_reader :string
 
   def [](n)
-    # XXX: if n is_a? Range
-    # XXX: when we have 2nd argument...
-    if n < 0
-      n += self.length
-      return nil if n < 0
-    elsif n >= self.length
-      return nil
-    end
-    b = self.begin(n)
-    e = self.end(n)
-    if b and e
-      @string[b, e-b]
+    if n.kind_of?(String) || n.kind_of?(Symbol)
+      indexes = regexp.named_captures[n.to_s]
+      if indexes
+        self[indexes.last]
+      else
+        nil
+      end
+    elsif n.respond_to?(:to_i)
+      # XXX: if n is_a? Range
+      # XXX: when we have 2nd argument...
+      n = n.to_i
+      if n < 0
+        n += self.length
+        return nil if n < 0
+      elsif n >= self.length
+        return nil
+      end
+      b = self.begin(n)
+      e = self.end(n)
+      if b and e
+        @string[b, e-b]
+      else
+        nil
+      end
     else
-      nil
+      raise TypeError.new("No implicit converstion of #{n.class} into integer")
     end
   end
 


### PR DESCRIPTION
I'd like to add the ability to get named capture group matches with the `MatchData::[]` method. They can be retrieved by passing the name as a `String` or `Symbol`, like MRI.

I also added an explicit type check on the paratem to `MatchData::[]`, and an error message to go along with it.

I can't get the `minirake test` task to run at the moment. Not sure why... but here's the behavior I'm after:

**Old Behavior**

```Ruby
[jared:~/projects/mruby] mirb
mirb - Embeddable Interactive Ruby Shell

> r = /(?<test>a)(b)(?:c)(?<test2>d)/
 => /(?<test>a)(b)(?:c)(?<test2>d)/
> m = r.match('abcd')
 => #<MatchData "abcd" 1:"a" 2:"b" 3:"d">
> m['test']
/Users/jared/projects/mruby/mrblib/compar.rb:16: comparison of String with Fixnum failed (ArgumentError)
> m[:test2]
/Users/jared/projects/mruby/mrblib/compar.rb:16: comparison of Symbol with Fixnum failed (ArgumentError)
> m[0]
 => "abcd"
> m[1]
 => "a"
> m[Object.new]
/Users/jared/projects/mruby-regexp-pcre/mrblib/regexp_pcre.rb:165: undefined method '<' for #<Object:0x7f94d3049c50> (NoMethodError)
```

**New Behavior**

```Ruby
[jared:~/projects/mruby] mirb
mirb - Embeddable Interactive Ruby Shell

> r = /(?<test>a)(b)(?:c)(?<test2>d)/
 => /(?<test>a)(b)(?:c)(?<test2>d)/
> m = r.match('abcd')
 => #<MatchData "abcd" 1:"a" 2:"b" 3:"d">
> m['test']
 => "a"
> m[:test2]
 => "d"
> m[0]
 => "abcd"
> m[1]
 => "a"
> m[Object.new]
/Users/jared/projects/mruby-regexp-pcre/mrblib/regexp_pcre.rb:179: No implicit converstion of Object into integer (TypeError)
```

Let me know if you see any issues! Thanks.