### PR TITLE
Add missing test dependency

### DIFF
--- a/mrblib/regexp_pcre.rb
+++ b/mrblib/regexp_pcre.rb
@@ -180,7 +180,7 @@ class MatchData
         nil
       end
     else
-      raise TypeError.new("No implicit converstion of #{n.class} into integer")
+      raise TypeError.new("No implicit conversion of #{n.class} into integer")
     end
   end
 

--- a/test/matchdata.rb
+++ b/test/matchdata.rb
@@ -1,3 +1,11 @@
+unless nil.respond_to? :to_i
+  class NilClass
+    def to_i
+      0
+    end
+  end
+end
+
 assert('MatchData', '15.2.16.2') do
   MatchData.class == Class and
   MatchData.superclass == Object


### PR DESCRIPTION
Test fails without non-core method `NilClass#to_i`