### PR TITLE
Fix String#match removed in mruby 2.1.0

### DIFF
--- a/mrblib/string_pcre.rb
+++ b/mrblib/string_pcre.rb
@@ -71,6 +71,10 @@ class String
     end
   end
 
+  def match(re, &block)
+    Regexp.new(re).match(self, &block)
+  end
+
   alias_method :old_split, :split
   def split(*args, &blk)
     return [] if self.empty?


### PR DESCRIPTION
String#=~ and String#match were removed from mruby for 2.1.0

 * https://github.com/mruby/mruby/commit/fd37bc53deb2d52fe3134838eab002dfb9ac35ab

String#=~ was already present, this adds the missing String#match.