### PR TITLE
Fix global match data ($1, ...) with 64 bit ints on armv7

### DIFF
--- a/src/mruby_regexp_pcre.c
+++ b/src/mruby_regexp_pcre.c
@@ -148,7 +148,8 @@ regexp_pcre_match(mrb_state *mrb, mrb_value self)
   int *match;
   struct RClass *c;
   mrb_value md, str;
-  mrb_int i, pos;
+  int i;
+  mrb_int pos;
   pcre_extra extra;
   struct mrb_regexp_pcre *reg;
 


### PR DESCRIPTION
When forcing `MRB_INT64` the following program outputs `nil` on armv7.

```ruby
"a".match(/^(a)$/)
puts $1.inspect
```

The compiler already was hinting to us this was problematic.

On armv7 with 64 bit mrb_int:

    .../mruby_regexp_pcre.c:203:35: warning: format '%d' expects argument of type 'int', but argument 4 has type 'mrb_int' {aka 'long long int'} [-Wformat=]

on x86_64 with 64 bit mrb_int:

    .../mruby_regexp_pcre.c:203:35: warning: format '%d' expects argument of type 'int', but argument 4 has type 'mrb_int' {aka 'long int'} [-Wformat=]

With this fix, no more warning.