### PR TITLE
Allow cross-compilation for windows

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -28,7 +28,7 @@ MRuby::Gem::Specification.new('mruby-regexp-pcre') do |spec|
   pcre_src = "#{spec.dir}/#{pcre_dirname}"
   spec.cc.include_paths << "#{pcre_src}"
   spec.cc.flags << '-DHAVE_CONFIG_H'
-  spec.cc.flags << '-DPCRE_STATIC' if /mingw|mswin/ =~ RUBY_PLATFORM
+  spec.cc.flags << '-DPCRE_STATIC' if for_windows?
 
   spec.objs += %W(
     #{pcre_src}/pcre_byte_order.c


### PR DESCRIPTION
# Why

By using `for_windows?` instead of checking just the current ruby host
platform we also handle the case where you're building from linux/osx
with mingw for windows.